### PR TITLE
fix: clear cached signed URLs for deleted receipts

### DIFF
--- a/src/lib/storage-utils.ts
+++ b/src/lib/storage-utils.ts
@@ -311,9 +311,15 @@ export async function deleteReceiptFiles(path: string): Promise<void> {
     throw new Error(`Failed to delete files: ${error.message}`)
   }
 
-  // Clear from cache
-  signedUrlCache.delete(`receipts:${path}:{}`)
-  signedUrlCache.delete(`receipts:${thumbnailPath}:{}`)
+  // Clear all cached URLs for this path and its thumbnail
+  for (const key of Array.from(signedUrlCache.keys())) {
+    if (
+      key.startsWith(`receipts:${path}:`) ||
+      key.startsWith(`receipts:${thumbnailPath}:`)
+    ) {
+      signedUrlCache.delete(key)
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- purge all cached signed URLs for a deleted receipt and its thumbnail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a502ba5f3c8328bec90e7770b22cb8